### PR TITLE
ERC20WithPermit token

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install Solidity
         env:
-          SOLC_VERSION: 0.8.4 # according to solidity.version in hardhat.config.js
+          SOLC_VERSION: 0.8.6 # according to solidity.version in hardhat.config.js
         run: |
           pip3 install solc-select
           solc-select install $SOLC_VERSION

--- a/contracts/test/ReceiveApprovalStub.sol
+++ b/contracts/test/ReceiveApprovalStub.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.4;
+
+import "../token/IReceiveApproval.sol";
+
+contract ReceiveApprovalStub is IReceiveApproval {
+    bool public shouldRevert;
+
+    event ApprovalReceived(
+        address from,
+        uint256 value,
+        address token,
+        bytes extraData
+    );
+
+    function receiveApproval(
+        address from,
+        uint256 value,
+        address token,
+        bytes calldata extraData
+    ) external override {
+        if (shouldRevert) {
+            revert("i am your father luke");
+        }
+
+        emit ApprovalReceived(from, value, token, extraData);
+    }
+
+    function setShouldRevert(bool _shouldRevert) external {
+        shouldRevert = _shouldRevert;
+    }
+}

--- a/contracts/test/ReceiveApprovalStub.sol
+++ b/contracts/test/ReceiveApprovalStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.0;
 
 import "../token/IReceiveApproval.sol";
 

--- a/contracts/test/ReceiveApprovalStub.sol
+++ b/contracts/test/ReceiveApprovalStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.5;
+pragma solidity ^0.8.4;
 
 import "../token/IReceiveApproval.sol";
 

--- a/contracts/test/ReceiveApprovalStub.sol
+++ b/contracts/test/ReceiveApprovalStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.5;
 
 import "../token/IReceiveApproval.sol";
 

--- a/contracts/token/ERC20WithPermit.sol
+++ b/contracts/token/ERC20WithPermit.sol
@@ -2,6 +2,224 @@
 
 pragma solidity 0.8.4;
 
-contract Erc20WithPermit {
-    // TODO will be implemented separately
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+import "./IERC20WithPermit.sol";
+import "./IReceiveApproval.sol";
+
+/// @title  ERC20WithPermit
+/// @notice Burnable ERC20 token with EIP2612 permit functionality. User can
+///         authorize a transfer of their token with a signature conforming
+///         EIP712 standard instead of an on-chain transaction from their
+///         address. Anyone can submit this signature on the user's behalf by
+///         calling the permit function, as specified in EIP2612 standard,
+///         paying gas fees, and possibly performing other actions in the same
+///         transaction.
+contract ERC20WithPermit is IERC20WithPermit, Ownable {
+    mapping(address => uint256) public override balanceOf;
+    mapping(address => mapping(address => uint256)) public override allowance;
+
+    mapping(address => uint256) public override nonces;
+
+    uint256 public immutable cachedChainId;
+    bytes32 public immutable cachedDomainSeparator;
+
+    // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 public constant override PERMIT_TYPEHASH =
+        0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+
+    uint256 public override totalSupply;
+
+    string public name;
+    string public symbol;
+
+    uint8 public constant decimals = 18;
+
+    constructor(string memory _name, string memory _symbol) {
+        name = _name;
+        symbol = _symbol;
+
+        cachedChainId = chainId();
+        cachedDomainSeparator = buildDomainSeparator();
+    }
+
+    function transfer(address recipient, uint256 amount)
+        external
+        override
+        returns (bool)
+    {
+        _transfer(msg.sender, recipient, amount);
+        return true;
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external override returns (bool) {
+        uint256 currentAllowance = allowance[sender][msg.sender];
+        if (currentAllowance != type(uint256).max) {
+            require(
+                currentAllowance >= amount,
+                "Transfer amount exceeds allowance"
+            );
+            _approve(sender, msg.sender, currentAllowance - amount);
+        }
+        _transfer(sender, recipient, amount);
+        return true;
+    }
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override {
+        /* solhint-disable-next-line not-rely-on-time */
+        require(deadline >= block.timestamp, "Permission expired");
+
+        // Validate `s` and `v` values for a malleability concern described in EIP2.
+        // Only signatures with `s` value in the lower half of the secp256k1
+        // curve's order and `v` value of 27 or 28 are considered valid.
+        require(
+            uint256(s) <=
+                0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,
+            "Invalid signature 's' value"
+        );
+        require(v == 27 || v == 28, "Invalid signature 'v' value");
+
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR(),
+                keccak256(
+                    abi.encode(
+                        PERMIT_TYPEHASH,
+                        owner,
+                        spender,
+                        amount,
+                        nonces[owner]++,
+                        deadline
+                    )
+                )
+            )
+        );
+        address recoveredAddress = ecrecover(digest, v, r, s);
+        require(
+            recoveredAddress != address(0) && recoveredAddress == owner,
+            "Invalid signature"
+        );
+        _approve(owner, spender, amount);
+    }
+
+    function mint(address recipient, uint256 amount) external onlyOwner {
+        require(recipient != address(0), "Mint to the zero address");
+        totalSupply += amount;
+        balanceOf[recipient] += amount;
+        emit Transfer(address(0), recipient, amount);
+    }
+
+    function burn(uint256 amount) external override {
+        _burn(msg.sender, amount);
+    }
+
+    function burnFrom(address account, uint256 amount) external override {
+        uint256 currentAllowance = allowance[account][msg.sender];
+        require(currentAllowance >= amount, "Burn amount exceeds allowance");
+        _approve(account, msg.sender, currentAllowance - amount);
+        _burn(account, amount);
+    }
+
+    function approveAndCall(
+        address spender,
+        uint256 value,
+        bytes memory extraData
+    ) external override returns (bool) {
+        if (approve(spender, value)) {
+            IReceiveApproval(spender).receiveApproval(
+                msg.sender,
+                value,
+                address(this),
+                extraData
+            );
+            return true;
+        }
+        return false;
+    }
+
+    function approve(address spender, uint256 amount)
+        public
+        override
+        returns (bool)
+    {
+        _approve(msg.sender, spender, amount);
+        return true;
+    }
+
+    /* solhint-disable-next-line func-name-mixedcase */
+    function DOMAIN_SEPARATOR() public view override returns (bytes32) {
+        if (chainId() == cachedChainId) {
+            return cachedDomainSeparator;
+        } else {
+            return buildDomainSeparator();
+        }
+    }
+
+    function _burn(address account, uint256 amount) internal {
+        uint256 currentBalance = balanceOf[account];
+        require(currentBalance >= amount, "Burn amount exceeds balance");
+        balanceOf[account] = currentBalance - amount;
+        totalSupply -= amount;
+        emit Transfer(account, address(0), amount);
+    }
+
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) private {
+        require(sender != address(0), "Transfer from the zero address");
+        require(recipient != address(0), "Transfer to the zero address");
+        uint256 senderBalance = balanceOf[sender];
+        require(senderBalance >= amount, "Transfer amount exceeds balance");
+        balanceOf[sender] = senderBalance - amount;
+        balanceOf[recipient] += amount;
+        emit Transfer(sender, recipient, amount);
+    }
+
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) private {
+        require(owner != address(0), "Approve from the zero address");
+        require(spender != address(0), "Approve to the zero address");
+        allowance[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    function buildDomainSeparator() private view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    keccak256(
+                        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                    ),
+                    keccak256(bytes(name)),
+                    keccak256(bytes("1")),
+                    chainId(),
+                    address(this)
+                )
+            );
+    }
+
+    function chainId() private view returns (uint256 id) {
+        /* solhint-disable-next-line no-inline-assembly */
+        assembly {
+            id := chainid()
+        }
+    }
 }

--- a/contracts/token/ERC20WithPermit.sol
+++ b/contracts/token/ERC20WithPermit.sol
@@ -191,7 +191,7 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
         _burn(account, amount);
     }
 
-    /// @notice Calls `receiveApproval` function on spender previusly approving
+    /// @notice Calls `receiveApproval` function on spender previously approving
     ///         the spender to withdraw from the caller multiple times, up to
     ///         the `amount` amount. If this function is called again, it
     ///         overwrites the current allowance with `amount`. Reverts if the
@@ -246,7 +246,7 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
         // As explained in EIP-2612, if the DOMAIN_SEPARATOR contains the
         // chainId and is defined at contract deployment instead of
         // reconstructed for every signature, there is a risk of possible replay
-        // attacks between chains in the event of a fututre chain split.
+        // attacks between chains in the event of a future chain split.
         // To address this issue, we check the cached chain ID against the
         // current one and in case they are different, we build domain separator
         // from scratch.

--- a/contracts/token/ERC20WithPermit.sol
+++ b/contracts/token/ERC20WithPermit.sol
@@ -128,8 +128,13 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
 
     function burnFrom(address account, uint256 amount) external override {
         uint256 currentAllowance = allowance[account][msg.sender];
-        require(currentAllowance >= amount, "Burn amount exceeds allowance");
-        _approve(account, msg.sender, currentAllowance - amount);
+        if (currentAllowance != type(uint256).max) {
+            require(
+                currentAllowance >= amount,
+                "Burn amount exceeds allowance"
+            );
+            _approve(account, msg.sender, currentAllowance - amount);
+        }
         _burn(account, amount);
     }
 

--- a/contracts/token/ERC20WithPermit.sol
+++ b/contracts/token/ERC20WithPermit.sol
@@ -30,10 +30,10 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
 
     uint256 public override totalSupply;
 
-    string public name;
-    string public symbol;
+    string public override name;
+    string public override symbol;
 
-    uint8 public constant decimals = 18;
+    uint8 public constant override decimals = 18;
 
     constructor(string memory _name, string memory _symbol) {
         name = _name;

--- a/contracts/token/ERC20WithPermit.sol
+++ b/contracts/token/ERC20WithPermit.sol
@@ -161,6 +161,13 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
 
     /* solhint-disable-next-line func-name-mixedcase */
     function DOMAIN_SEPARATOR() public view override returns (bytes32) {
+        // As explained in EIP-2612, if the DOMAIN_SEPARATOR contains the
+        // chainId and is defined at contract deployment instead of
+        // reconstructed for every signature, there is a risk of possible replay
+        // attacks between chains in the event of a fututre chain split.
+        // To address this issue, we check the cached chain ID against the
+        // current one and in case they are different, we build domain separator
+        // from scratch.
         if (chainId() == cachedChainId) {
             return cachedDomainSeparator;
         } else {

--- a/contracts/token/ERC20WithPermit.sol
+++ b/contracts/token/ERC20WithPermit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/token/ERC20WithPermit.sol
+++ b/contracts/token/ERC20WithPermit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.5;
+pragma solidity ^0.8.4;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/token/ERC20WithPermit.sol
+++ b/contracts/token/ERC20WithPermit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.5;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/token/IApproveAndCall.sol
+++ b/contracts/token/IApproveAndCall.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.5;
+pragma solidity ^0.8.4;
 
 /// @notice An interface that should be implemented by tokens supporting
 ///         `approveAndCall`/`receiveApproval` pattern.

--- a/contracts/token/IApproveAndCall.sol
+++ b/contracts/token/IApproveAndCall.sol
@@ -5,15 +5,15 @@ pragma solidity ^0.8.5;
 /// @notice An interface that should be implemented by tokens supporting
 ///         `approveAndCall`/`receiveApproval` pattern.
 interface IApproveAndCall {
-    /// @notice Executes receiveApproval function on spender as specified in
-    ///         IReceiveApproval interface. Approves spender to withdraw from
-    ///         the caller multiple times, up to the value amount. If this
+    /// @notice Executes `receiveApproval` function on spender as specified in
+    ///         `IReceiveApproval` interface. Approves spender to withdraw from
+    ///         the caller multiple times, up to the `amount`. If this
     ///         function is called again, it overwrites the current allowance
-    ///         with value. Reverts if the approval reverted or if
-    ///         receiveApproval call on the spender reverted.
+    ///         with `amount`. Reverts if the approval reverted or if
+    ///         `receiveApproval` call on the spender reverted.
     function approveAndCall(
         address spender,
-        uint256 value,
+        uint256 amount,
         bytes memory extraData
     ) external returns (bool);
 }

--- a/contracts/token/IApproveAndCall.sol
+++ b/contracts/token/IApproveAndCall.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.5;
+
+/// @notice An interface that should be implemented by tokens supporting
+///         `approveAndCall`/`receiveApproval` pattern.
+interface IApproveAndCall {
+    /// @notice Executes receiveApproval function on spender as specified in
+    ///         IReceiveApproval interface. Approves spender to withdraw from
+    ///         the caller multiple times, up to the value amount. If this
+    ///         function is called again, it overwrites the current allowance
+    ///         with value. Reverts if the approval reverted or if
+    ///         receiveApproval call on the spender reverted.
+    function approveAndCall(
+        address spender,
+        uint256 value,
+        bytes memory extraData
+    ) external returns (bool);
+}

--- a/contracts/token/IERC20WithPermit.sol
+++ b/contracts/token/IERC20WithPermit.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
 /// @title  IERC20WithPermit
 /// @notice Burnable ERC20 token with EIP2612 permit functionality. User can
@@ -12,7 +13,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 ///         calling the permit function, as specified in EIP2612 standard,
 ///         paying gas fees, and possibly performing other actions in the same
 ///         transaction.
-interface IERC20WithPermit is IERC20 {
+interface IERC20WithPermit is IERC20, IERC20Metadata {
     /// @notice EIP2612 approval made with secp256k1 signature.
     ///         Users can authorize a transfer of their tokens with a signature
     ///         conforming EIP712 standard, rather than an on-chain transaction

--- a/contracts/token/IERC20WithPermit.sol
+++ b/contracts/token/IERC20WithPermit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.5;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";

--- a/contracts/token/IERC20WithPermit.sol
+++ b/contracts/token/IERC20WithPermit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/token/IERC20WithPermit.sol
+++ b/contracts/token/IERC20WithPermit.sol
@@ -22,8 +22,8 @@ interface IERC20WithPermit is IERC20, IERC20Metadata, IApproveAndCall {
     ///         from their address. Anyone can submit this signature on the
     ///         user's behalf by calling the permit function, paying gas fees,
     ///         and possibly performing other actions in the same transaction.
-    /// @dev    The deadline argument can be set to uint(-1) to create permits
-    ///         that effectively never expire.
+    /// @dev    The deadline argument can be set to `type(uint256).max to create
+    ///         permits that effectively never expire.
     function permit(
         address owner,
         address spender,

--- a/contracts/token/IERC20WithPermit.sol
+++ b/contracts/token/IERC20WithPermit.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.4;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @title  IERC20WithPermit
+/// @notice Burnable ERC20 token with EIP2612 permit functionality. User can
+///         authorize a transfer of their token with a signature conforming
+///         EIP712 standard instead of an on-chain transaction from their
+///         address. Anyone can submit this signature on the user's behalf by
+///         calling the permit function, as specified in EIP2612 standard,
+///         paying gas fees, and possibly performing other actions in the same
+///         transaction.
+interface IERC20WithPermit is IERC20 {
+    /// @notice EIP2612 approval made with secp256k1 signature.
+    ///         Users can authorize a transfer of their tokens with a signature
+    ///         conforming EIP712 standard, rather than an on-chain transaction
+    ///         from their address. Anyone can submit this signature on the
+    ///         user's behalf by calling the permit function, paying gas fees,
+    ///         and possibly performing other actions in the same transaction.
+    /// @dev    The deadline argument can be set to uint(-1) to create permits
+    ///         that effectively never expire.
+    function permit(
+        address owner,
+        address spender,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    /// @notice Destroys `amount` tokens from the caller.
+    function burn(uint256 amount) external;
+
+    /// @notice Destroys `amount` of tokens from `account`, deducting the amount
+    ///         from caller's allowance.
+    function burnFrom(address account, uint256 amount) external;
+
+    /// @notice Executes receiveApproval function on spender as specified in
+    ///         IReceiveApproval interface. Approves spender to withdraw from
+    ///         the caller multiple times, up to the value amount. If this
+    ///         function is called again, it overwrites the current allowance
+    ///         with value. Reverts if the approval reverted or if
+    ///         receiveApproval call on the spender reverted.
+    function approveAndCall(
+        address spender,
+        uint256 value,
+        bytes memory extraData
+    ) external returns (bool);
+
+    /// @notice Returns hash of EIP712 Domain struct with the token name as
+    ///         a signing domain and token contract as a verifying contract.
+    ///         Used to construct EIP2612 signature provided to `permit`
+    ///         function.
+    /* solhint-disable-next-line func-name-mixedcase */
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+
+    /// @notice Returns the current nonce for EIP2612 permission for the
+    ///         provided token owner for a replay protection. Used to construct
+    ///         EIP2612 signature provided to `permit` function.
+    function nonces(address owner) external view returns (uint256);
+
+    /// @notice Returns EIP2612 Permit message hash. Used to construct EIP2612
+    ///         signature provided to `permit` function.
+    /* solhint-disable-next-line func-name-mixedcase */
+    function PERMIT_TYPEHASH() external pure returns (bytes32);
+}

--- a/contracts/token/IERC20WithPermit.sol
+++ b/contracts/token/IERC20WithPermit.sol
@@ -5,6 +5,8 @@ pragma solidity ^0.8.5;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
+import "./IApproveAndCall.sol";
+
 /// @title  IERC20WithPermit
 /// @notice Burnable ERC20 token with EIP2612 permit functionality. User can
 ///         authorize a transfer of their token with a signature conforming
@@ -13,7 +15,7 @@ import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 ///         calling the permit function, as specified in EIP2612 standard,
 ///         paying gas fees, and possibly performing other actions in the same
 ///         transaction.
-interface IERC20WithPermit is IERC20, IERC20Metadata {
+interface IERC20WithPermit is IERC20, IERC20Metadata, IApproveAndCall {
     /// @notice EIP2612 approval made with secp256k1 signature.
     ///         Users can authorize a transfer of their tokens with a signature
     ///         conforming EIP712 standard, rather than an on-chain transaction
@@ -38,18 +40,6 @@ interface IERC20WithPermit is IERC20, IERC20Metadata {
     /// @notice Destroys `amount` of tokens from `account`, deducting the amount
     ///         from caller's allowance.
     function burnFrom(address account, uint256 amount) external;
-
-    /// @notice Executes receiveApproval function on spender as specified in
-    ///         IReceiveApproval interface. Approves spender to withdraw from
-    ///         the caller multiple times, up to the value amount. If this
-    ///         function is called again, it overwrites the current allowance
-    ///         with value. Reverts if the approval reverted or if
-    ///         receiveApproval call on the spender reverted.
-    function approveAndCall(
-        address spender,
-        uint256 value,
-        bytes memory extraData
-    ) external returns (bool);
 
     /// @notice Returns hash of EIP712 Domain struct with the token name as
     ///         a signing domain and token contract as a verifying contract.

--- a/contracts/token/IERC20WithPermit.sol
+++ b/contracts/token/IERC20WithPermit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.5;
+pragma solidity ^0.8.4;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";

--- a/contracts/token/IReceiveApproval.sol
+++ b/contracts/token/IReceiveApproval.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.4;
+
+/// @notice An interface that should be implemented by contracts supporting
+///         `approveAndCall`/`receiveApproval` pattern.
+interface IReceiveApproval {
+    function receiveApproval(
+        address from,
+        uint256 value,
+        address token,
+        bytes calldata extraData
+    ) external;
+}

--- a/contracts/token/IReceiveApproval.sol
+++ b/contracts/token/IReceiveApproval.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.5;
 
 /// @notice An interface that should be implemented by contracts supporting
 ///         `approveAndCall`/`receiveApproval` pattern.

--- a/contracts/token/IReceiveApproval.sol
+++ b/contracts/token/IReceiveApproval.sol
@@ -5,6 +5,8 @@ pragma solidity ^0.8.5;
 /// @notice An interface that should be implemented by contracts supporting
 ///         `approveAndCall`/`receiveApproval` pattern.
 interface IReceiveApproval {
+    /// @notice Receives approval to spend tokens. Called as a result of
+    ///         approveAndCall call on the token.
     function receiveApproval(
         address from,
         uint256 value,

--- a/contracts/token/IReceiveApproval.sol
+++ b/contracts/token/IReceiveApproval.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.4;
+pragma solidity ^0.8.0;
 
 /// @notice An interface that should be implemented by contracts supporting
 ///         `approveAndCall`/`receiveApproval` pattern.

--- a/contracts/token/IReceiveApproval.sol
+++ b/contracts/token/IReceiveApproval.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.5;
+pragma solidity ^0.8.4;
 
 /// @notice An interface that should be implemented by contracts supporting
 ///         `approveAndCall`/`receiveApproval` pattern.

--- a/contracts/token/IReceiveApproval.sol
+++ b/contracts/token/IReceiveApproval.sol
@@ -6,10 +6,10 @@ pragma solidity ^0.8.5;
 ///         `approveAndCall`/`receiveApproval` pattern.
 interface IReceiveApproval {
     /// @notice Receives approval to spend tokens. Called as a result of
-    ///         approveAndCall call on the token.
+    ///         `approveAndCall` call on the token.
     function receiveApproval(
         address from,
-        uint256 value,
+        uint256 amount,
         address token,
         bytes calldata extraData
     ) external;

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -3,6 +3,6 @@ require("hardhat-gas-reporter")
 
 module.exports = {
   solidity: {
-    version: "0.8.4",
+    version: "0.8.6",
   },
 }

--- a/test/ERC20WithPermit.test.js
+++ b/test/ERC20WithPermit.test.js
@@ -1,7 +1,0 @@
-const { expect } = require("chai")
-
-describe("ERC20WithPermit", () => {
-  it("should work", async () => {
-    expect(true).to.be.true
-  })
-})

--- a/test/helpers/contract-test-helpers.js
+++ b/test/helpers/contract-test-helpers.js
@@ -1,0 +1,13 @@
+function to1e18(n) {
+  const decimalMultiplier = ethers.BigNumber.from(10).pow(18)
+  return ethers.BigNumber.from(n).mul(decimalMultiplier)
+}
+
+async function lastBlockTime() {
+  return (await ethers.provider.getBlock("latest")).timestamp
+}
+
+module.exports.to1e18 = to1e18
+module.exports.lastBlockTime = lastBlockTime
+
+module.exports.ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"

--- a/test/helpers/contract-test-helpers.js
+++ b/test/helpers/contract-test-helpers.js
@@ -7,7 +7,17 @@ async function lastBlockTime() {
   return (await ethers.provider.getBlock("latest")).timestamp
 }
 
+async function increaseTime(time) {
+  const now = await lastBlockTime()
+  await ethers.provider.send("evm_setNextBlockTimestamp", [now + time])
+  await ethers.provider.send("evm_mine")
+}
+
 module.exports.to1e18 = to1e18
 module.exports.lastBlockTime = lastBlockTime
+module.exports.increaseTime = increaseTime
 
 module.exports.ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+module.exports.MAX_UINT256 = ethers.BigNumber.from(
+  "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+)

--- a/test/token/ERC20WithPermit.test.js
+++ b/test/token/ERC20WithPermit.test.js
@@ -49,7 +49,7 @@ describe("ERC20WithPermit", () => {
     })
   })
 
-  describe("permit_typehash", () => {
+  describe("PERMIT_TYPEHASH", () => {
     it("should be keccak256 of EIP2612 Permit message", async () => {
       const expected = ethers.utils.keccak256(
         ethers.utils.toUtf8Bytes(
@@ -60,7 +60,7 @@ describe("ERC20WithPermit", () => {
     })
   })
 
-  describe("domain_separator", () => {
+  describe("DOMAIN_SEPARATOR", () => {
     it("should be keccak256 of EIP712 domain struct", async () => {
       const keccak256 = ethers.utils.keccak256
       const defaultAbiCoder = ethers.utils.defaultAbiCoder

--- a/test/token/ERC20WithPermit.test.js
+++ b/test/token/ERC20WithPermit.test.js
@@ -1,0 +1,1069 @@
+const { expect } = require("chai")
+const {
+  lastBlockTime,
+  to1e18,
+  ZERO_ADDRESS,
+} = require("../helpers/contract-test-helpers")
+
+describe("ERC20WithPermit", () => {
+  // default Hardhat's networks blockchain, see https://hardhat.org/config/
+  const hardhatNetworkId = 31337
+
+  const initialSupply = to1e18(100)
+
+  let owner
+  let initialHolder
+  let recipient
+  let anotherAccount
+
+  let token
+
+  beforeEach(async () => {
+    ;[owner, initialHolder, recipient, anotherAccount] =
+      await ethers.getSigners()
+
+    const ERC20WithPermit = await ethers.getContractFactory("ERC20WithPermit")
+    token = await ERC20WithPermit.deploy("My Token", "MT")
+    await token.deployed()
+
+    await token.mint(initialHolder.address, initialSupply)
+  })
+
+  it("should have a name", async () => {
+    expect(await token.name()).to.equal("My Token")
+  })
+
+  it("should have a symbol", async () => {
+    expect(await token.symbol()).to.equal("MT")
+  })
+
+  it("should have 18 decimals", async () => {
+    expect(await token.decimals()).to.equal(18)
+  })
+
+  describe("totalSupply", () => {
+    it("should return the total amount of tokens", async () => {
+      expect(await token.totalSupply()).to.equal(initialSupply)
+    })
+  })
+
+  describe("permit_typehash", () => {
+    it("should be keccak256 of EIP2612 Permit message", async () => {
+      const expected = ethers.utils.keccak256(
+        ethers.utils.toUtf8Bytes(
+          "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+        )
+      )
+      expect(await token.PERMIT_TYPEHASH()).to.equal(expected)
+    })
+  })
+
+  describe("domain_separator", () => {
+    it("should be keccak256 of EIP712 domain struct", async () => {
+      const keccak256 = ethers.utils.keccak256
+      const defaultAbiCoder = ethers.utils.defaultAbiCoder
+      const toUtf8Bytes = ethers.utils.toUtf8Bytes
+
+      const expected = keccak256(
+        defaultAbiCoder.encode(
+          ["bytes32", "bytes32", "bytes32", "uint256", "address"],
+          [
+            keccak256(
+              toUtf8Bytes(
+                "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+              )
+            ),
+            keccak256(toUtf8Bytes("My Token")),
+            keccak256(toUtf8Bytes("1")),
+            hardhatNetworkId,
+            token.address,
+          ]
+        )
+      )
+      expect(await token.DOMAIN_SEPARATOR()).to.equal(expected)
+    })
+  })
+
+  describe("balanceOf", () => {
+    context("when the requested account has no tokens", () => {
+      it("should return zero", async () => {
+        expect(await token.balanceOf(anotherAccount.address)).to.equal(0)
+      })
+    })
+
+    context("when the requested account has some tokens", () => {
+      it("should return the total amount of tokens", async () => {
+        expect(await token.balanceOf(initialHolder.address)).to.equal(
+          initialSupply
+        )
+      })
+    })
+  })
+
+  describe("transfer", () => {
+    context("when the recipient is not the zero address", () => {
+      context("when the sender does not have enough balance", () => {
+        const amount = initialSupply.add(1)
+
+        it("should revert", async () => {
+          await expect(
+            token.connect(initialHolder).transfer(recipient.address, amount)
+          ).to.be.revertedWith("Transfer amount exceeds balance")
+        })
+      })
+
+      context("when the sender transfers all balance", () => {
+        const amount = initialSupply
+
+        it("should transfer the requested amount", async () => {
+          await token.connect(initialHolder).transfer(recipient.address, amount)
+
+          expect(await token.balanceOf(initialHolder.address)).to.equal(0)
+
+          expect(await token.balanceOf(recipient.address)).to.equal(amount)
+        })
+
+        it("should emit a transfer event", async () => {
+          const tx = await token
+            .connect(initialHolder)
+            .transfer(recipient.address, amount)
+
+          await expect(tx)
+            .to.emit(token, "Transfer")
+            .withArgs(initialHolder.address, recipient.address, amount)
+        })
+      })
+
+      context("when the sender transfers zero tokens", () => {
+        const amount = ethers.BigNumber.from(0)
+
+        it("should transfer the requested amount", async () => {
+          await token.connect(initialHolder).transfer(recipient.address, amount)
+
+          expect(await token.balanceOf(initialHolder.address)).to.equal(
+            initialSupply
+          )
+
+          expect(await token.balanceOf(recipient.address)).to.equal(0)
+        })
+
+        it("should emit a transfer event", async () => {
+          const tx = await token
+            .connect(initialHolder)
+            .transfer(recipient.address, amount)
+
+          await expect(tx)
+            .to.emit(token, "Transfer")
+            .withArgs(initialHolder.address, recipient.address, amount)
+        })
+      })
+    })
+
+    context("when the recipient is the zero address", () => {
+      it("should revert", async () => {
+        await expect(
+          token.connect(initialHolder).transfer(ZERO_ADDRESS, initialSupply)
+        ).to.be.revertedWith("Transfer to the zero address")
+      })
+    })
+  })
+
+  describe("transferFrom", () => {
+    context("when the token owner is not the zero address", () => {
+      context("when the recipient is not the zero address", () => {
+        context("when the spender has enough approved balance", () => {
+          const allowance = initialSupply
+          beforeEach(async function () {
+            await token
+              .connect(initialHolder)
+              .approve(anotherAccount.address, allowance)
+          })
+
+          context("when the token owner has enough balance", () => {
+            const amount = initialSupply
+
+            it("should transfer the requested amount", async () => {
+              await token
+                .connect(anotherAccount)
+                .transferFrom(initialHolder.address, recipient.address, amount)
+
+              expect(await token.balanceOf(initialHolder.address)).to.equal(0)
+
+              expect(await token.balanceOf(recipient.address)).to.equal(amount)
+            })
+
+            it("should decrease the spender allowance", async () => {
+              await token
+                .connect(anotherAccount)
+                .transferFrom(initialHolder.address, recipient.address, amount)
+
+              expect(
+                await token.allowance(
+                  initialHolder.address,
+                  anotherAccount.address
+                )
+              ).to.equal(0)
+            })
+
+            it("should emit a transfer event", async () => {
+              const tx = await token
+                .connect(anotherAccount)
+                .transferFrom(initialHolder.address, recipient.address, amount)
+
+              await expect(tx)
+                .to.emit(token, "Transfer")
+                .withArgs(initialHolder.address, recipient.address, amount)
+            })
+
+            it("should emit an approval event", async () => {
+              const tx = await token
+                .connect(anotherAccount)
+                .transferFrom(initialHolder.address, recipient.address, amount)
+
+              await expect(tx)
+                .to.emit(token, "Approval")
+                .withArgs(
+                  initialHolder.address,
+                  anotherAccount.address,
+                  allowance.sub(amount)
+                )
+            })
+          })
+
+          context("when the token owner does not have enough balance", () => {
+            const amount = initialSupply
+
+            beforeEach(async () => {
+              await token
+                .connect(initialHolder)
+                .transfer(anotherAccount.address, 1)
+            })
+
+            it("should revert", async () => {
+              await expect(
+                token
+                  .connect(anotherAccount)
+                  .transferFrom(
+                    initialHolder.address,
+                    recipient.address,
+                    amount
+                  )
+              ).to.be.revertedWith("Transfer amount exceeds balance")
+            })
+          })
+        })
+
+        context(
+          "when the spender does not have enough approved balance",
+          () => {
+            const allowance = initialSupply.sub(1)
+
+            beforeEach(async () => {
+              await token
+                .connect(initialHolder)
+                .approve(anotherAccount.address, allowance)
+            })
+
+            context("when the token owner has enough balance", () => {
+              const amount = initialSupply
+
+              it("should revert", async () => {
+                await expect(
+                  token
+                    .connect(anotherAccount)
+                    .transferFrom(
+                      initialHolder.address,
+                      recipient.address,
+                      amount
+                    )
+                ).to.be.revertedWith("Transfer amount exceeds allowance")
+              })
+            })
+
+            context("when the token owner does not have enough balance", () => {
+              const amount = initialSupply
+
+              beforeEach(async () => {
+                await token
+                  .connect(initialHolder)
+                  .transfer(anotherAccount.address, 1)
+              })
+
+              it("should revert", async () => {
+                await expect(
+                  token
+                    .connect(anotherAccount)
+                    .transferFrom(
+                      initialHolder.address,
+                      recipient.address,
+                      amount
+                    )
+                ).to.be.revertedWith("Transfer amount exceeds allowance")
+              })
+            })
+
+            context("when the token owner is the zero address", () => {
+              const allowance = initialSupply
+
+              it("should revert", async () => {
+                await expect(
+                  token
+                    .connect(anotherAccount)
+                    .transferFrom(ZERO_ADDRESS, recipient.address, allowance)
+                ).to.be.revertedWith("Transfer amount exceeds allowance")
+              })
+            })
+          }
+        )
+      })
+
+      context("when the recipient is the zero address", () => {
+        const allowance = initialSupply
+
+        beforeEach(async () => {
+          await token
+            .connect(initialHolder)
+            .approve(anotherAccount.address, allowance)
+        })
+
+        it("should revert", async () => {
+          await expect(
+            token
+              .connect(anotherAccount)
+              .transferFrom(initialHolder.address, ZERO_ADDRESS, allowance)
+          ).to.be.revertedWith("Transfer to the zero address")
+        })
+      })
+    })
+  })
+
+  describe("approve", () => {
+    context("when the spender is not the zero address", () => {
+      context("when the sender has enough balance", () => {
+        const allowance = initialSupply
+
+        it("should emit an approval event", async () => {
+          const tx = await token
+            .connect(initialHolder)
+            .approve(anotherAccount.address, allowance)
+
+          await expect(tx)
+            .to.emit(token, "Approval")
+            .withArgs(initialHolder.address, anotherAccount.address, allowance)
+        })
+
+        context("when there was no approved amount before", () => {
+          it("should approve the requested amount", async () => {
+            await token
+              .connect(initialHolder)
+              .approve(anotherAccount.address, allowance)
+
+            expect(
+              await token.allowance(
+                initialHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(allowance)
+          })
+        })
+
+        context("when the spender had an approved amount", () => {
+          beforeEach(async () => {
+            await token
+              .connect(initialHolder)
+              .approve(anotherAccount.address, allowance)
+          })
+
+          it("should approve the requested amount and replaces the previous one", async () => {
+            const newAllowance = to1e18(100)
+
+            await token
+              .connect(initialHolder)
+              .approve(anotherAccount.address, newAllowance)
+            expect(
+              await token.allowance(
+                initialHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(newAllowance)
+          })
+        })
+      })
+
+      context("when the sender does not have enough balance", () => {
+        const allowance = initialSupply.add(1)
+
+        it("should emit an approval event", async () => {
+          const tx = await token
+            .connect(initialHolder)
+            .approve(anotherAccount.address, allowance)
+
+          await expect(tx)
+            .to.emit(token, "Approval")
+            .withArgs(initialHolder.address, anotherAccount.address, allowance)
+        })
+
+        context("when there was no approved amount before", () => {
+          it("should approve the requested amount", async () => {
+            await token
+              .connect(initialHolder)
+              .approve(anotherAccount.address, allowance)
+
+            expect(
+              await token.allowance(
+                initialHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(allowance)
+          })
+        })
+
+        context("when the spender had an approved amount", () => {
+          beforeEach(async () => {
+            await token
+              .connect(initialHolder)
+              .approve(anotherAccount.address, to1e18(1))
+          })
+
+          it("should approve the requested amount and replaces the previous one", async () => {
+            await token
+              .connect(initialHolder)
+              .approve(anotherAccount.address, allowance)
+            expect(
+              await token.allowance(
+                initialHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(allowance)
+          })
+        })
+      })
+    })
+
+    context("when the spender is the zero address", () => {
+      const allowance = initialSupply
+      it("should revert", async () => {
+        await expect(
+          token.connect(initialHolder).approve(ZERO_ADDRESS, allowance)
+        ).to.be.revertedWith("Approve to the zero address")
+      })
+    })
+  })
+
+  describe("mint", () => {
+    const amount = to1e18(50)
+    it("should reject a zero account", async () => {
+      await expect(
+        token.connect(owner).mint(ZERO_ADDRESS, amount)
+      ).to.be.revertedWith("Mint to the zero address")
+    })
+
+    context("when called not by the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          token.connect(initialHolder).mint(initialHolder.address, amount)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("for a non zero account", () => {
+      let mintTx
+      beforeEach("minting", async () => {
+        mintTx = await token.connect(owner).mint(anotherAccount.address, amount)
+      })
+
+      it("should incement totalSupply", async () => {
+        const expectedSupply = initialSupply.add(amount)
+        expect(await token.totalSupply()).to.equal(expectedSupply)
+      })
+
+      it("should increment recipient balance", async () => {
+        expect(await token.balanceOf(anotherAccount.address)).to.equal(amount)
+      })
+
+      it("should emit Transfer event", async () => {
+        await expect(mintTx)
+          .to.emit(token, "Transfer")
+          .withArgs(ZERO_ADDRESS, anotherAccount.address, amount)
+      })
+    })
+  })
+
+  describe("burn", () => {
+    it("should reject burning more than balance", async () => {
+      await expect(
+        token.connect(initialHolder).burn(initialSupply.add(1))
+      ).to.be.revertedWith("Burn amount exceeds balance")
+    })
+
+    const describeBurn = (description, amount) => {
+      describe(description, () => {
+        let burnTx
+        beforeEach("burning", async () => {
+          burnTx = await token.connect(initialHolder).burn(amount)
+        })
+
+        it("should decrement totalSupply", async () => {
+          const expectedSupply = initialSupply.sub(amount)
+          expect(await token.totalSupply()).to.equal(expectedSupply)
+        })
+
+        it("should decrement owner's balance", async () => {
+          const expectedBalance = initialSupply.sub(amount)
+          expect(await token.balanceOf(initialHolder.address)).to.equal(
+            expectedBalance
+          )
+        })
+
+        it("should emit Transfer event", async () => {
+          await expect(burnTx)
+            .to.emit(token, "Transfer")
+            .withArgs(initialHolder.address, ZERO_ADDRESS, amount)
+        })
+      })
+    }
+
+    describeBurn("for entire balance", initialSupply)
+    describeBurn("for less amount than balance", initialSupply.sub(1))
+  })
+
+  describe("burnFrom", () => {
+    it("should reject burning more than balance", async () => {
+      await token
+        .connect(initialHolder)
+        .approve(anotherAccount.address, initialSupply.add(1))
+      await expect(
+        token
+          .connect(anotherAccount)
+          .burnFrom(initialHolder.address, initialSupply.add(1))
+      ).to.be.revertedWith("Burn amount exceeds balance")
+    })
+
+    it("should reject burning more than the allowance", async () => {
+      await token
+        .connect(initialHolder)
+        .approve(anotherAccount.address, initialSupply.sub(1))
+      await expect(
+        token
+          .connect(anotherAccount)
+          .burnFrom(initialHolder.address, initialSupply)
+      ).to.be.revertedWith("Burn amount exceeds allowance")
+    })
+
+    const describeBurnFrom = (description, amount) => {
+      describe(description, () => {
+        let burnTx
+        beforeEach("burning from", async () => {
+          await token
+            .connect(initialHolder)
+            .approve(anotherAccount.address, amount)
+          burnTx = await token
+            .connect(anotherAccount)
+            .burnFrom(initialHolder.address, amount)
+        })
+
+        it("should decrement totalSupply", async () => {
+          const expectedSupply = initialSupply.sub(amount)
+          expect(await token.totalSupply()).to.equal(expectedSupply)
+        })
+
+        it("should decrement owner's balance", async () => {
+          const expectedBalance = initialSupply.sub(amount)
+          expect(await token.balanceOf(initialHolder.address)).to.equal(
+            expectedBalance
+          )
+        })
+
+        it("should decrement allowance", async () => {
+          const allowance = await token.allowance(
+            initialHolder.address,
+            anotherAccount.address
+          )
+
+          expect(allowance).to.equal(0)
+        })
+
+        it("should emit Transfer event", async () => {
+          await expect(burnTx)
+            .to.emit(token, "Transfer")
+            .withArgs(initialHolder.address, ZERO_ADDRESS, amount)
+        })
+      })
+    }
+
+    describeBurnFrom("for entire balance", initialSupply)
+    describeBurnFrom("for less amount than balance", initialSupply.sub(1))
+  })
+
+  describe("permit", () => {
+    const permittingHolderBalance = to1e18(650000)
+    let permittingHolder
+
+    let yesterday
+    let tomorrow
+
+    beforeEach(async () => {
+      permittingHolder = await ethers.Wallet.createRandom()
+      await token.mint(permittingHolder.address, permittingHolderBalance)
+
+      const lastBlockTimestamp = await lastBlockTime()
+      yesterday = lastBlockTimestamp - 86400 // -1 day
+      tomorrow = lastBlockTimestamp + 86400 // +1 day
+    })
+
+    const getApproval = async (amount, spender, deadline) => {
+      // We use ethers.utils.SigningKey for a Wallet instead of
+      // Signer.signMessage to do not add '\x19Ethereum Signed Message:\n'
+      // prefix to the signed message. The '\x19` protection (see EIP191 for
+      // more details on '\x19' rationale and format) is already included in
+      // EIP2612 permit signed message and '\x19Ethereum Signed Message:\n'
+      // should not be used there.
+      const signingKey = new ethers.utils.SigningKey(
+        permittingHolder.privateKey
+      )
+
+      const domainSeparator = await token.DOMAIN_SEPARATOR()
+      const permitTypehash = await token.PERMIT_TYPEHASH()
+      const nonce = await token.nonces(permittingHolder.address)
+
+      const approvalDigest = ethers.utils.keccak256(
+        ethers.utils.solidityPack(
+          ["bytes1", "bytes1", "bytes32", "bytes32"],
+          [
+            "0x19",
+            "0x01",
+            domainSeparator,
+            ethers.utils.keccak256(
+              ethers.utils.defaultAbiCoder.encode(
+                [
+                  "bytes32",
+                  "address",
+                  "address",
+                  "uint256",
+                  "uint256",
+                  "uint256",
+                ],
+                [
+                  permitTypehash,
+                  permittingHolder.address,
+                  spender,
+                  amount,
+                  nonce,
+                  deadline,
+                ]
+              )
+            ),
+          ]
+        )
+      )
+
+      return ethers.utils.splitSignature(
+        await signingKey.signDigest(approvalDigest)
+      )
+    }
+
+    context("when permission expired", () => {
+      it("should revert", async () => {
+        const deadline = yesterday
+        const signature = await getApproval(
+          permittingHolderBalance,
+          anotherAccount.address,
+          deadline
+        )
+
+        await expect(
+          token
+            .connect(anotherAccount)
+            .permit(
+              permittingHolder.address,
+              anotherAccount.address,
+              permittingHolderBalance,
+              deadline,
+              signature.v,
+              signature.r,
+              signature.s
+            )
+        ).to.be.revertedWith("Permission expired")
+      })
+    })
+
+    context("when permission has an invalid signature", () => {
+      it("should revert", async () => {
+        const deadline = tomorrow
+        const signature = await getApproval(
+          permittingHolderBalance,
+          anotherAccount.address,
+          deadline
+        )
+
+        await expect(
+          token.connect(anotherAccount).permit(
+            anotherAccount.address, // does not match the signature
+            anotherAccount.address,
+            permittingHolderBalance,
+            deadline,
+            signature.v,
+            signature.r,
+            signature.s
+          )
+        ).to.be.revertedWith("Invalid signature")
+      })
+    })
+
+    context("when the spender is not the zero address", () => {
+      context("when the sender has enough balance", () => {
+        const allowance = permittingHolderBalance
+        it("should emit an approval event", async () => {
+          const deadline = tomorrow
+          const signature = await getApproval(
+            allowance,
+            anotherAccount.address,
+            deadline
+          )
+
+          const tx = await token
+            .connect(anotherAccount)
+            .permit(
+              permittingHolder.address,
+              anotherAccount.address,
+              allowance,
+              deadline,
+              signature.v,
+              signature.r,
+              signature.s
+            )
+
+          await expect(tx)
+            .to.emit(token, "Approval")
+            .withArgs(
+              permittingHolder.address,
+              anotherAccount.address,
+              allowance
+            )
+        })
+
+        context("when there was no approved amount before", () => {
+          it("should approve the requested amount", async () => {
+            const deadline = tomorrow
+            const signature = await getApproval(
+              allowance,
+              anotherAccount.address,
+              deadline
+            )
+
+            await token
+              .connect(anotherAccount)
+              .permit(
+                permittingHolder.address,
+                anotherAccount.address,
+                allowance,
+                deadline,
+                signature.v,
+                signature.r,
+                signature.s
+              )
+
+            expect(
+              await token.allowance(
+                permittingHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(allowance)
+          })
+        })
+
+        context("when the spender had an approved amount", () => {
+          beforeEach(async () => {
+            const deadline = tomorrow
+            const initialAllowance = allowance.sub(10)
+            const signature = await getApproval(
+              initialAllowance,
+              anotherAccount.address,
+              deadline
+            )
+
+            await token
+              .connect(anotherAccount)
+              .permit(
+                permittingHolder.address,
+                anotherAccount.address,
+                initialAllowance,
+                deadline,
+                signature.v,
+                signature.r,
+                signature.s
+              )
+          })
+
+          it("should approve the requested amount and replaces the previous one", async () => {
+            const deadline = tomorrow
+            const signature = await getApproval(
+              allowance,
+              anotherAccount.address,
+              deadline
+            )
+
+            await token
+              .connect(anotherAccount)
+              .permit(
+                permittingHolder.address,
+                anotherAccount.address,
+                allowance,
+                deadline,
+                signature.v,
+                signature.r,
+                signature.s
+              )
+
+            expect(
+              await token.allowance(
+                permittingHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(allowance)
+          })
+        })
+      })
+
+      context("when the sender does not have enough balance", () => {
+        const allowance = permittingHolderBalance.add(1)
+        it("should emit an approval event", async () => {
+          const deadline = tomorrow
+          const signature = await getApproval(
+            allowance,
+            anotherAccount.address,
+            deadline
+          )
+
+          const tx = await token
+            .connect(anotherAccount)
+            .permit(
+              permittingHolder.address,
+              anotherAccount.address,
+              allowance,
+              deadline,
+              signature.v,
+              signature.r,
+              signature.s
+            )
+
+          await expect(tx)
+            .to.emit(token, "Approval")
+            .withArgs(
+              permittingHolder.address,
+              anotherAccount.address,
+              allowance
+            )
+        })
+
+        context("when there was no approved amount before", () => {
+          it("should approve the requested amount", async () => {
+            const deadline = tomorrow
+            const signature = await getApproval(
+              allowance,
+              anotherAccount.address,
+              deadline
+            )
+
+            await token
+              .connect(anotherAccount)
+              .permit(
+                permittingHolder.address,
+                anotherAccount.address,
+                allowance,
+                deadline,
+                signature.v,
+                signature.r,
+                signature.s
+              )
+
+            expect(
+              await token.allowance(
+                permittingHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(allowance)
+          })
+        })
+
+        context("when the spender had an approved amount", () => {
+          beforeEach(async () => {
+            const deadline = tomorrow
+            const initialAllowance = allowance.sub(10)
+            const signature = await getApproval(
+              initialAllowance,
+              anotherAccount.address,
+              deadline
+            )
+
+            await token
+              .connect(anotherAccount)
+              .permit(
+                permittingHolder.address,
+                anotherAccount.address,
+                initialAllowance,
+                deadline,
+                signature.v,
+                signature.r,
+                signature.s
+              )
+          })
+
+          it("should approve the requested amount and replaces the previous one", async () => {
+            const deadline = tomorrow
+            const signature = await getApproval(
+              allowance,
+              anotherAccount.address,
+              deadline
+            )
+
+            await token
+              .connect(anotherAccount)
+              .permit(
+                permittingHolder.address,
+                anotherAccount.address,
+                allowance,
+                deadline,
+                signature.v,
+                signature.r,
+                signature.s
+              )
+
+            expect(
+              await token.allowance(
+                permittingHolder.address,
+                anotherAccount.address
+              )
+            ).to.equal(allowance)
+          })
+        })
+      })
+    })
+
+    context("when the spender is the zero address", () => {
+      const allowance = permittingHolderBalance
+      it("should revert", async () => {
+        const deadline = tomorrow
+        const signature = await getApproval(allowance, ZERO_ADDRESS, deadline)
+
+        await expect(
+          token
+            .connect(anotherAccount)
+            .permit(
+              permittingHolder.address,
+              ZERO_ADDRESS,
+              allowance,
+              deadline,
+              signature.v,
+              signature.r,
+              signature.s
+            )
+        ).to.be.revertedWith("Approve to the zero address")
+      })
+    })
+
+    context("when given never expiring permit", () => {
+      // uint(-1)
+      const allowance = ethers.BigNumber.from(
+        "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+      )
+
+      beforeEach(async () => {
+        const deadline = tomorrow
+        const signature = await getApproval(
+          allowance,
+          anotherAccount.address,
+          deadline
+        )
+
+        await token
+          .connect(anotherAccount)
+          .permit(
+            permittingHolder.address,
+            anotherAccount.address,
+            allowance,
+            deadline,
+            signature.v,
+            signature.r,
+            signature.s
+          )
+      })
+      it("should not reduce approved amount", async () => {
+        expect(
+          await token.allowance(
+            permittingHolder.address,
+            anotherAccount.address
+          )
+        ).to.equal(allowance)
+
+        await token
+          .connect(anotherAccount)
+          .transferFrom(
+            permittingHolder.address,
+            recipient.address,
+            to1e18(100)
+          )
+
+        expect(
+          await token.allowance(
+            permittingHolder.address,
+            anotherAccount.address
+          )
+        ).to.equal(allowance)
+      })
+    })
+  })
+
+  describe("approveAndCall", () => {
+    const amount = to1e18(3)
+    let approvalReceiver
+
+    beforeEach(async () => {
+      const ReceiveApprovalStub = await ethers.getContractFactory(
+        "ReceiveApprovalStub"
+      )
+      approvalReceiver = await ReceiveApprovalStub.deploy()
+      await approvalReceiver.deployed()
+    })
+
+    context("when approval fails", () => {
+      it("should revert", async () => {
+        await expect(
+          token.connect(initialHolder).approveAndCall(ZERO_ADDRESS, amount, [])
+        ).to.be.reverted
+      })
+    })
+
+    context("when receiveApproval fails", () => {
+      beforeEach(async () => {
+        await approvalReceiver.setShouldRevert(true)
+      })
+
+      it("should revert", async () => {
+        await expect(
+          token
+            .connect(initialHolder)
+            .approveAndCall(approvalReceiver.address, amount, [])
+        ).to.be.revertedWith("i am your father luke")
+      })
+    })
+
+    it("approves the provided amount for transfer", async () => {
+      await token
+        .connect(initialHolder)
+        .approveAndCall(approvalReceiver.address, amount, [])
+      expect(
+        await token.allowance(initialHolder.address, approvalReceiver.address)
+      ).to.equal(amount)
+    })
+
+    it("calls approveAndCall with the provided parameters", async () => {
+      const tx = await token
+        .connect(initialHolder)
+        .approveAndCall(approvalReceiver.address, amount, "0xbeef")
+      await expect(tx)
+        .to.emit(approvalReceiver, "ApprovalReceived")
+        .withArgs(initialHolder.address, amount, token.address, "0xbeef")
+    })
+  })
+})


### PR DESCRIPTION
Generic implementation of ERC20 token with permit functionality, used
already in [keep-network/tbtc-v2](https://github.com/keep-network/tbtc-v2) and [keep-network/coverage-pools](https://github.com/keep-network/coverage-pools/).

User can authorize a transfer of their token with a signature conforming
EIP712 standard instead of an on-chain transaction from their address.
Anyone can submit this signature on the user's behalf by calling `permit`
function, as specified in EIP2612, paying gas fees, and possibly
performing other actions in the same transaction.

By the time of implementing this contract, to my knowledge, there is no
other audited EP2612 token implementation other than Uniswap V2 on which
this code is based on. OpenZeppelin has quite recently added `permit` to
their ERC20 but this code is still in a draft state, was released in the
most recent version of the library, and to my understanding was not
audited yet by another firm, and could have breaking change in the
future.

The implementation mostly mirrors UniswapV2ERC20. It adds some tweaks
from OpenZeppelin ERC20 implementation such as more meaningful revert
messages and Approval event emitted on calls to `transferFrom`. This
allows applications to reconstruct the allowance for all accounts just
by listening to the event. Additionally, this token implements
`approveAndCall` pattern.

Unit tests were based on OpenZeppelin ERC20 unit tests with our own
tests implementation for EIP2612 and EIP712. The token code in  
[keep-network/tbtc-v2](https://github.com/keep-network/tbtc-v2) this is is a ctrlc/ctrlv was audited by ToB.