### PR TITLE
Compute PERMIT_TYPEHASH constant instead of hardcoding it

### DIFF
--- a/contracts/token/ERC20WithPermit.sol
+++ b/contracts/token/ERC20WithPermit.sol
@@ -34,9 +34,10 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
 
     /// @notice Returns EIP2612 Permit message hash. Used to construct EIP2612
     ///         signature provided to `permit` function.
-    // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
     bytes32 public constant override PERMIT_TYPEHASH =
-        0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+        keccak256(
+            "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+        );
 
     /// @notice The amount of tokens in existence.
     uint256 public override totalSupply;

--- a/test/token/ERC20WithPermit.test.js
+++ b/test/token/ERC20WithPermit.test.js
@@ -53,7 +53,8 @@ describe("ERC20WithPermit", () => {
 
   describe("PERMIT_TYPEHASH", () => {
     it("should be keccak256 of EIP2612 Permit message", async () => {
-      const expected = "0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9"
+      const expected =
+        "0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9"
       expect(await token.PERMIT_TYPEHASH()).to.equal(expected)
     })
   })

--- a/test/token/ERC20WithPermit.test.js
+++ b/test/token/ERC20WithPermit.test.js
@@ -53,11 +53,7 @@ describe("ERC20WithPermit", () => {
 
   describe("PERMIT_TYPEHASH", () => {
     it("should be keccak256 of EIP2612 Permit message", async () => {
-      const expected = ethers.utils.keccak256(
-        ethers.utils.toUtf8Bytes(
-          "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
-        )
-      )
+      const expected = "0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9"
       expect(await token.PERMIT_TYPEHASH()).to.equal(expected)
     })
   })


### PR DESCRIPTION
Instead of hardcoding the result of keccak256 and explaining in a
comment where does the particular value come from, we compute it
when assigning PERMIT_TYPEHASH value.

I believe the intention behing the original version was to make
deployment a little cheaper, however the compiler should be inteligent
enough to optimize it.