### PR TITLE
Renamed _beforeTokenTransfer to beforeTokenTransfer

### DIFF
--- a/contracts/test/token/ERC20WithPermitStub.sol
+++ b/contracts/test/token/ERC20WithPermitStub.sol
@@ -11,7 +11,7 @@ contract ERC20WithPermitStub is ERC20WithPermit {
         ERC20WithPermit(_name, _symbol)
     {}
 
-    function _beforeTokenTransfer(
+    function beforeTokenTransfer(
         address from,
         address to,
         uint256 amount

--- a/contracts/token/ERC20WithPermit.sol
+++ b/contracts/token/ERC20WithPermit.sol
@@ -162,7 +162,7 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
     function mint(address recipient, uint256 amount) external onlyOwner {
         require(recipient != address(0), "Mint to the zero address");
 
-        _beforeTokenTransfer(address(0), recipient, amount);
+        beforeTokenTransfer(address(0), recipient, amount);
 
         totalSupply += amount;
         balanceOf[recipient] += amount;
@@ -271,7 +271,7 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
     /// - when `to` is zero, `amount` of ``from``'s tokens will be burned.
     /// - `from` and `to` are never both zero.
     // slither-disable-next-line dead-code
-    function _beforeTokenTransfer(
+    function beforeTokenTransfer(
         address from,
         address to,
         uint256 amount
@@ -281,7 +281,7 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
         uint256 currentBalance = balanceOf[account];
         require(currentBalance >= amount, "Burn amount exceeds balance");
 
-        _beforeTokenTransfer(account, address(0), amount);
+        beforeTokenTransfer(account, address(0), amount);
 
         balanceOf[account] = currentBalance - amount;
         totalSupply -= amount;
@@ -296,7 +296,7 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
         require(sender != address(0), "Transfer from the zero address");
         require(recipient != address(0), "Transfer to the zero address");
 
-        _beforeTokenTransfer(sender, recipient, amount);
+        beforeTokenTransfer(sender, recipient, amount);
 
         uint256 senderBalance = balanceOf[sender];
         require(senderBalance >= amount, "Transfer amount exceeds balance");

--- a/test/token/ERC20WithPermit.test.js
+++ b/test/token/ERC20WithPermit.test.js
@@ -135,7 +135,7 @@ describe("ERC20WithPermit", () => {
             .withArgs(initialHolder.address, recipient.address, amount)
         })
 
-        it("should call _beforeTokenTransfer hook", async () => {
+        it("should call beforeTokenTransfer hook", async () => {
           await expect(tx)
             .to.emit(token, "BeforeTokenTransferCalled")
             .withArgs(initialHolder.address, recipient.address, amount)
@@ -166,7 +166,7 @@ describe("ERC20WithPermit", () => {
             .withArgs(initialHolder.address, recipient.address, amount)
         })
 
-        it("should call _beforeTokenTransfer hook", async () => {
+        it("should call beforeTokenTransfer hook", async () => {
           await expect(tx)
             .to.emit(token, "BeforeTokenTransferCalled")
             .withArgs(initialHolder.address, recipient.address, amount)
@@ -235,7 +235,7 @@ describe("ERC20WithPermit", () => {
                 )
             })
 
-            it("should call _beforeTokenTransfer hook", async () => {
+            it("should call beforeTokenTransfer hook", async () => {
               await expect(tx)
                 .to.emit(token, "BeforeTokenTransferCalled")
                 .withArgs(initialHolder.address, recipient.address, amount)
@@ -524,7 +524,7 @@ describe("ERC20WithPermit", () => {
           .withArgs(ZERO_ADDRESS, anotherAccount.address, amount)
       })
 
-      it("should call _beforeTokenTransfer hook", async () => {
+      it("should call beforeTokenTransfer hook", async () => {
         await expect(mintTx)
           .to.emit(token, "BeforeTokenTransferCalled")
           .withArgs(ZERO_ADDRESS, anotherAccount.address, amount)
@@ -564,7 +564,7 @@ describe("ERC20WithPermit", () => {
             .withArgs(initialHolder.address, ZERO_ADDRESS, amount)
         })
 
-        it("should call _beforeTokenTransfer hook", async () => {
+        it("should call beforeTokenTransfer hook", async () => {
           await expect(burnTx)
             .to.emit(token, "BeforeTokenTransferCalled")
             .withArgs(initialHolder.address, ZERO_ADDRESS, amount)
@@ -638,7 +638,7 @@ describe("ERC20WithPermit", () => {
             .withArgs(initialHolder.address, ZERO_ADDRESS, amount)
         })
 
-        it("should call _beforeTokenTransfer hook", async () => {
+        it("should call beforeTokenTransfer hook", async () => {
           await expect(burnTx)
             .to.emit(token, "BeforeTokenTransferCalled")
             .withArgs(initialHolder.address, ZERO_ADDRESS, amount)


### PR DESCRIPTION
We do not prefix functions with _ just before they are internal. We only
prefix them if they conflict with another code. This is not the case for
`beforeTokenTransfer`.

It is a follow-up of PR #6.