### PR TITLE
Misfunds

### DIFF
--- a/contracts/test/token/TestERC20.sol
+++ b/contracts/test/token/TestERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import "../../token/ERC20WithPermit.sol";
+
+contract TestERC20 is ERC20WithPermit {
+    string public constant NAME = "Test ERC20 Token";
+    string public constant SYMBOL = "TT";
+
+    constructor() ERC20WithPermit(NAME, SYMBOL) {}
+}

--- a/contracts/test/token/TestERC721.sol
+++ b/contracts/test/token/TestERC721.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract TestERC721 is ERC721 {
+    string public constant NAME = "Test ERC721 Token";
+    string public constant SYMBOL = "TT";
+
+    constructor() ERC721(NAME, SYMBOL) {}
+
+    function mint(address to, uint256 tokenId) public {
+        _mint(to, tokenId);
+    }
+}

--- a/contracts/token/ERC20WithPermit.sol
+++ b/contracts/token/ERC20WithPermit.sol
@@ -295,6 +295,7 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
     ) private {
         require(sender != address(0), "Transfer from the zero address");
         require(recipient != address(0), "Transfer to the zero address");
+        require(recipient != address(this), "Transfer to the token address");
 
         beforeTokenTransfer(sender, recipient, amount);
 

--- a/contracts/token/MisfundRecovery.sol
+++ b/contracts/token/MisfundRecovery.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+/// @title  MisfundRecovery
+/// @notice Allows the owner of the token contract extending MisfundRecovery
+///         to recover any ERC20 and ERC721 sent mistakenly to the token
+///         contract address.
+contract MisfundRecovery is Ownable {
+    using SafeERC20 for IERC20;
+
+    function recoverERC20(
+        IERC20 token,
+        address recipient,
+        uint256 amount
+    ) external onlyOwner {
+        token.safeTransfer(recipient, amount);
+    }
+
+    function recoverERC721(
+        IERC721 token,
+        address recipient,
+        uint256 tokenId,
+        bytes calldata data
+    ) external onlyOwner {
+        token.safeTransferFrom(address(this), recipient, tokenId, data);
+    }
+}

--- a/test/token/ERC20WithPermit.test.js
+++ b/test/token/ERC20WithPermit.test.js
@@ -181,6 +181,14 @@ describe("ERC20WithPermit", () => {
         ).to.be.revertedWith("Transfer to the zero address")
       })
     })
+
+    context("when the recipient is the token address", () => {
+      it("should revert", async () => {
+        await expect(
+          token.connect(initialHolder).transfer(token.address, initialSupply)
+        ).to.be.revertedWith("Transfer to the token address")
+      })
+    })
   })
 
   describe("transferFrom", () => {
@@ -344,6 +352,24 @@ describe("ERC20WithPermit", () => {
               .connect(anotherAccount)
               .transferFrom(initialHolder.address, ZERO_ADDRESS, allowance)
           ).to.be.revertedWith("Transfer to the zero address")
+        })
+      })
+
+      context("when the recipient is the token address", () => {
+        const allowance = initialSupply
+
+        beforeEach(async () => {
+          await token
+            .connect(initialHolder)
+            .approve(anotherAccount.address, allowance)
+        })
+
+        it("should revert", async () => {
+          await expect(
+            token
+              .connect(anotherAccount)
+              .transferFrom(initialHolder.address, token.address, allowance)
+          ).to.be.revertedWith("Transfer to the token address")
         })
       })
 

--- a/test/token/MisfundRecovery.test.js
+++ b/test/token/MisfundRecovery.test.js
@@ -1,0 +1,88 @@
+const { to1e18 } = require("../helpers/contract-test-helpers")
+
+const { expect } = require("chai")
+
+describe("MisfundRecovery", () => {
+  let recoveryOwner
+  let thirdParty
+
+  let randomERC20
+  let randomERC721
+
+  let recovery
+
+  beforeEach(async () => {
+    ;[deployer, recoveryOwner, thirdParty] = await ethers.getSigners()
+
+    const MisfundRecovery = await ethers.getContractFactory("MisfundRecovery")
+    recovery = await MisfundRecovery.deploy()
+    await recovery.deployed()
+
+    const TestERC20 = await ethers.getContractFactory("TestERC20")
+    randomERC20 = await TestERC20.deploy()
+    await randomERC20.deployed()
+
+    const TestERC721 = await ethers.getContractFactory("TestERC721")
+    randomERC721 = await TestERC721.deploy()
+    await randomERC721.deployed()
+
+    await recovery.connect(deployer).transferOwnership(recoveryOwner.address)
+  })
+
+  describe("recoverERC20", () => {
+    const amount = to1e18(725)
+
+    beforeEach(async () => {
+      await randomERC20.mint(recovery.address, amount)
+    })
+
+    context("when called not by the owner", () => {
+      it("reverts", async () => {
+        await expect(
+          recovery
+            .connect(thirdParty)
+            .recoverERC20(randomERC20.address, thirdParty.address, amount)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the owner", () => {
+      it("transfers tokens to the recipient", async () => {
+        await recovery
+          .connect(recoveryOwner)
+          .recoverERC20(randomERC20.address, thirdParty.address, amount)
+        expect(await randomERC20.balanceOf(thirdParty.address)).to.equal(amount)
+      })
+    })
+  })
+
+  describe("recoverERC721", () => {
+    const tokenId = 19112
+
+    beforeEach(async () => {
+      await randomERC721.mint(recovery.address, tokenId)
+    })
+
+    context("when called not by the owner", () => {
+      it("reverts", async () => {
+        await expect(
+          recovery.recoverERC721(
+            randomERC721.address,
+            thirdParty.address,
+            tokenId,
+            []
+          )
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when called by the owner", () => {
+      it("transfers token to the recipient", async () => {
+        await recovery
+          .connect(recoveryOwner)
+          .recoverERC721(randomERC721.address, thirdParty.address, tokenId, [])
+        expect(await randomERC721.ownerOf(tokenId)).to.equal(thirdParty.address)
+      })
+    })
+  })
+})


### PR DESCRIPTION
`MisfundRecovery` allows any `Ownable` contract extending it to recover
ERC20 or ERC721 sent mistakenly to the contract address. It is expected
to be used with `ERC20WithPermit` as the most misfund cases we noticed in
our network were about sending tokens to the token address.

This logic was extracted from `keep-network/tbtc-v2` repository, introduced 
originally here: https://github.com/keep-network/tbtc-v2/pull/4.

Additionally, we now disallow in `ERC20WithPermit` transferring the token to the
contract address.

