### PR TITLE
Added a note to CloneFactory about 0x0 create opcode result

### DIFF
--- a/contracts/clone/CloneFactory.sol
+++ b/contracts/clone/CloneFactory.sol
@@ -33,6 +33,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 abstract contract CloneFactory {
     /// @notice Creates EIP-1167 clone of the contract under the provided
     ///         `target` address. Returns address of the created clone.
+    /// @dev In specific circumstances, such as the `target` contract destroyed,
+    ///      create opcode may return 0x0 address. The code calling this
+    ///      function should handle this corner case properly.
     function createClone(address target) internal returns (address result) {
         bytes20 targetBytes = bytes20(target);
         assembly {


### PR DESCRIPTION
Added @dev note to `createClone` doc to emphasize the calling code should
handle 0x0 case properly. That is, when the target contract has been
destroyed, the function will return 0x0.