### PR TITLE
Add a GH Actions workflow publishing npm package with contracts

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - "contracts/**"
       - "package.json"
-      - "package-lock.json"
+      - "yarn.json"
   workflow_dispatch:
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"
-          cache: "npm"
+          cache: "yarn"
           registry-url: "https://registry.npmjs.org"
 
       - name: Bump up package version

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - "contracts/**"
       - "package.json"
-      - "yarn.json"
+      - "yarn.lock"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,36 @@
+name: NPM
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "contracts/**"
+      - "package.json"
+      - "package-lock.json"
+  workflow_dispatch:
+
+jobs:
+  npm-compile-publish-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Bump up package version
+        id: npm-version-bump
+        uses: keep-network/npm-version-bump@v2
+        with:
+          environment: dev
+          branch: ${{ github.ref }}
+          commit: ${{ github.sha }}
+
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --tag development

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -26,11 +26,11 @@ jobs:
         id: npm-version-bump
         uses: keep-network/npm-version-bump@v2
         with:
-          environment: dev
+          environment: pre
           branch: ${{ github.ref }}
           commit: ${{ github.sha }}
 
       - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --tag development
+        run: npm publish --access public --tag pre

--- a/package.json
+++ b/package.json
@@ -1,7 +1,18 @@
 {
-  "name": "@thesis/solidity-contracts",
-  "version": "0.0.1",
+  "name": "@thesis-co/solidity-contracts",
+  "version": "0.0.1-dev",
   "license": "MIT",
+  "files": [
+    "contracts/**/*.sol"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/thesis/solidity-contracts"
+  },
+  "bugs": {
+    "url": "https://github.com/thesis/solidity-contracts/issues"
+  },
+  "homepage": "https://github.com/thesis/solidity-contracts",
   "scripts": {
     "build": "hardhat compile",
     "format": "npm run lint && prettier --check .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thesis-co/solidity-contracts",
-  "version": "0.0.1-dev",
+  "version": "0.0.1-pre",
   "license": "MIT",
   "files": [
     "contracts/**/*.sol"


### PR DESCRIPTION
Contracts stored in the `thesis/solidity-contracts` repository are used
as a dependency in other projects. Currently they are pulled from the
GitHub and referenced to by commit hash.
In this PR we add a GH Actions workflow that will publish npm
packages containing `*.sol` contracts and version them using `-pre.X`
suffix.

TODO:
- [x] set NPM_TOKEN secret to `@thesis-co`
- [x] push first npm package to the `@thesis-co/solidity-contracts` registry, in order to get the bump-up step working

Closes: https://github.com/thesis/solidity-contracts/issues/13