### PR TITLE
EIP-2612 compliance fix: n/nonce/nonces

### DIFF
--- a/contracts/token/ERC20WithPermit.sol
+++ b/contracts/token/ERC20WithPermit.sol
@@ -27,7 +27,7 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
     /// @notice Returns the current nonce for EIP2612 permission for the
     ///         provided token owner for a replay protection. Used to construct
     ///         EIP2612 signature provided to `permit` function.
-    mapping(address => uint256) public override nonce;
+    mapping(address => uint256) public override nonces;
 
     uint256 public immutable cachedChainId;
     bytes32 public immutable cachedDomainSeparator;
@@ -141,7 +141,7 @@ contract ERC20WithPermit is IERC20WithPermit, Ownable {
                         owner,
                         spender,
                         amount,
-                        nonce[owner]++,
+                        nonces[owner]++,
                         deadline
                     )
                 )

--- a/contracts/token/IERC20WithPermit.sol
+++ b/contracts/token/IERC20WithPermit.sol
@@ -51,7 +51,7 @@ interface IERC20WithPermit is IERC20, IERC20Metadata, IApproveAndCall {
     /// @notice Returns the current nonce for EIP2612 permission for the
     ///         provided token owner for a replay protection. Used to construct
     ///         EIP2612 signature provided to `permit` function.
-    function nonce(address owner) external view returns (uint256);
+    function nonces(address owner) external view returns (uint256);
 
     /// @notice Returns EIP2612 Permit message hash. Used to construct EIP2612
     ///         signature provided to `permit` function.

--- a/test/token/ERC20WithPermit.test.js
+++ b/test/token/ERC20WithPermit.test.js
@@ -904,7 +904,7 @@ describe("ERC20WithPermit", () => {
 
       const domainSeparator = await token.DOMAIN_SEPARATOR()
       const permitTypehash = await token.PERMIT_TYPEHASH()
-      const nonce = await token.nonce(permittingHolder.address)
+      const nonce = await token.nonces(permittingHolder.address)
 
       const approvalDigest = ethers.utils.keccak256(
         ethers.utils.solidityPack(
@@ -1101,7 +1101,7 @@ describe("ERC20WithPermit", () => {
             deadline
           )
 
-          const initialNonce = await token.nonce(permittingHolder.address)
+          const initialNonce = await token.nonces(permittingHolder.address)
 
           await token
             .connect(anotherAccount)
@@ -1115,11 +1115,11 @@ describe("ERC20WithPermit", () => {
               signature.s
             )
 
-          expect(await token.nonce(permittingHolder.address)).to.equal(
+          expect(await token.nonces(permittingHolder.address)).to.equal(
             initialNonce.add(1)
           )
-          expect(await token.nonce(anotherAccount.address)).to.equal(0)
-          expect(await token.nonce(recipient.address)).to.equal(0)
+          expect(await token.nonces(anotherAccount.address)).to.equal(0)
+          expect(await token.nonces(recipient.address)).to.equal(0)
         })
 
         context("when there was no approved amount before", () => {


### PR DESCRIPTION
The ERC20WithPermit implements EIP-2612 but used mapping `nonce` (singular)
instead of `nonces`. This might create an issue when third-party libraries
(that support EIP-2612) try to interact with the token and assume that nonces are
tracked with `nonces` instead of `nonce`. Fixed it by renaming `nonce` mapping
to `nonces`.